### PR TITLE
WTEL-9275: Send default file policy message

### DIFF
--- a/bot/gateway.go
+++ b/bot/gateway.go
@@ -1103,6 +1103,14 @@ func (c *Gateway) SendServiceMessageByTemplate(ctx context.Context, templateName
 		return err
 	}
 	if text == "" {
+		text = defaultServiceMessageText[templateName]
+		if text != "" {
+			c.Log.Warn("service message template not configured; using default",
+				slog.String("template", templateName),
+			)
+		}
+	}
+	if text == "" {
 		return nil
 	}
 	msg := &chat.Message{

--- a/bot/service.go
+++ b/bot/service.go
@@ -41,6 +41,12 @@ const (
 	DefaultFilePolicyMessage = "Forbidden file format"
 )
 
+// defaultServiceMessageText returns hardcoded fallback for templates that
+// must reach the agent even when the gateway has no configured text.
+var defaultServiceMessageText = map[string]string{
+	FilePolicyFailType: DefaultFilePolicyMessage,
+}
+
 // Service intercomunnication proxy
 type Service struct {
 	// cmd/bot.Service

--- a/bot/templates_test.go
+++ b/bot/templates_test.go
@@ -77,6 +77,7 @@ func TestTemplate_MessageText(t *testing.T) {
 		{"title", args{"title", &templatePeer}, "<José Antonio Domínguez Bandera> aka @banderas", false},
 		{"join", args{"join", &templatePeer}, "md2: 👤 *José Antonio* ||Domínguez Bandera||", false},
 		{"left", args{"left", &templatePeer}, "md2: 👤 ~*José Antonio* ||Domínguez Bandera||~", false},
+		{"file_policy_fail not registered", args{"file_policy_fail", nil}, "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Причина
- `SendServiceMessageByTemplate` у `bot/gateway.go` мовчки виходив (`return nil`) при порожньому шаблоні, без публікації.

## Рішення
- Додано map `defaultServiceMessageText` у `bot/service.go` для шаблонів, які мають обов'язково доходити до агента.
- У `SendServiceMessageByTemplate` підстановка дефолту з map'а + `Warn`-лог для видимості неналаштованих шлюзів.
- Інші шаблони (`close`/`title`/`join`/`left`) залишаються silent-skip, адмін може свідомо їх вимкнути.

## Зміни
- `bot/service.go` — новий map.
- `bot/gateway.go` — fallback + warn-лог.
- `bot/templates_test.go` — кейс для незареєстрованого шаблону.
