### PR TITLE
WTEL-9475: Guard nil interactive in WhatsApp webhook

### DIFF
--- a/bot/facebook/whatsapp.go
+++ b/bot/facebook/whatsapp.go
@@ -1739,6 +1739,20 @@ func (c *Client) whatsAppOnMessages(ctx context.Context, update *whatsapp.Update
 				}
 			}
 
+			// Interactive object MAY NOT be provided
+			if interactive == nil {
+				c.Gateway.Log.Warn("whatsApp.onMessage",
+					slog.String("error", "interactive: missing object"),
+					slog.String("to", recipient.PhoneNumber),   // WhatsApp [PhoneNumber] Display
+					slog.String("to:wa", recipient.ID),         // WhatsApp [PhoneNumber] ID
+					slog.String("to:ba", recipient.Account.ID), // WhatsApp [BusinessAccount] ID
+					slog.String("chat", update.Product),        // "whatsapp"
+					slog.String("from", contact.Contact),       // PHONE_NUMBER
+					slog.String("user", contact.DisplayName()),
+				)
+				continue // next: message(s)
+			}
+
 			switch interactive.Type {
 			case "button_reply":
 				// "interactive": {
@@ -1749,6 +1763,19 @@ func (c *Client) whatsAppOnMessages(ctx context.Context, update *whatsapp.Update
 				// 	}
 				// }
 				reply := interactive.QuickReply
+				if reply == nil {
+					c.Gateway.Log.Warn("whatsApp.onMessageReply",
+						slog.String("interactive", interactive.Type),
+						slog.String("error", "button_reply: missing object"),
+						slog.String("to", recipient.PhoneNumber),   // WhatsApp [PhoneNumber] Display
+						slog.String("to:wa", recipient.ID),         // WhatsApp [PhoneNumber] ID
+						slog.String("to:ba", recipient.Account.ID), // WhatsApp [BusinessAccount] ID
+						slog.String("chat", update.Product),        // "whatsapp"
+						slog.String("from", contact.Contact),       // PHONE_NUMBER
+						slog.String("user", contact.DisplayName()),
+					)
+					continue // next: message(s)
+				}
 				text := reply.ID // button.code
 
 				sendMsg.Type = "text"
@@ -1764,6 +1791,19 @@ func (c *Client) whatsAppOnMessages(ctx context.Context, update *whatsapp.Update
 				// 	}
 				// }
 				reply := interactive.ListReply
+				if reply == nil {
+					c.Gateway.Log.Warn("whatsApp.onMessageReply",
+						slog.String("interactive", interactive.Type),
+						slog.String("error", "list_reply: missing object"),
+						slog.String("to", recipient.PhoneNumber),   // WhatsApp [PhoneNumber] Display
+						slog.String("to:wa", recipient.ID),         // WhatsApp [PhoneNumber] ID
+						slog.String("to:ba", recipient.Account.ID), // WhatsApp [BusinessAccount] ID
+						slog.String("chat", update.Product),        // "whatsapp"
+						slog.String("from", contact.Contact),       // PHONE_NUMBER
+						slog.String("user", contact.DisplayName()),
+					)
+					continue // next: message(s)
+				}
 				text := reply.ID // button.code
 
 				sendMsg.Type = "text"


### PR DESCRIPTION
## Проблема
У проді [messages-bot] падала паніка при обробці вебхука WhatsApp Cloud API:
  runtime error: invalid memory address or nil pointer dereference bot/facebook/whatsapp.go:1742
  
Падіння трапляється, коли Meta надсилає повідомлення з "type": "interactive", але без об'єкта interactive у тілі JSON. Після json.Unmarshal поле Message.Interactive (вказівник *Interactive) залишається nil, а код одразу робить switch interactive.Type, що дає nil-pointer dereference на розіменуванні.

Поряд у case "interactive" є дві аналогічні небезпечні точки, де розіменовуються interactive.QuickReply (*Button) і interactive.ListReply (*Button). Вони теж можуть бути nil, якщо приходить "type": 
  "button_reply" чи "list_reply" без вкладеного об'єкта.

##  Вирішення
У whatsAppOnMessages додано три точкові nil-гарди у гілці case "interactive".