### PR TITLE
WTEL-9275: Surface file_policy_fail marker in WS event

### DIFF
--- a/bot/gateway.go
+++ b/bot/gateway.go
@@ -1102,7 +1102,8 @@ func (c *Gateway) SendServiceMessageByTemplate(ctx context.Context, templateName
 	if err != nil {
 		return err
 	}
-	if text == "" {
+	if text == "" && templateName != FilePolicyFailType {
+		// file_policy_fail must always emit a marker so the FE can render its placeholder
 		return nil
 	}
 	msg := &chat.Message{

--- a/cmd/chat/service.go
+++ b/cmd/chat/service.go
@@ -2425,10 +2425,15 @@ func (c *chatService) saveMessage(ctx context.Context, dcx sqlx.ExtContext, send
 		}
 
 		if text == "" {
-			return nil, errors.BadRequest(
-				"chat.send.message.text.missing",
-				"send: message text is missing",
-			)
+			// allow empty text for the file_policy_fail placeholder marker so the
+			// FE can render its own stub (no template configured on the gateway)
+			vars := sendMessage.GetVariables()
+			if vars["from"] != "bot" || vars["template"] != FilePolicyFailType {
+				return nil, errors.BadRequest(
+					"chat.send.message.text.missing",
+					"send: message text is missing",
+				)
+			}
 		}
 		// reset: normalized !
 		sendMessage.Text = text
@@ -3168,8 +3173,15 @@ func (c *chatService) sendSystemLevelMessage(ctx context.Context, sender *app.Ch
 				}
 				channelID := member.Chat.ID
 				vars := notify.GetVariables()
-				if vars != nil && vars["from"] == "bot" && vars["template"] == FilePolicyFailType {
-					channelID = "" // hide channelId to mark system messages
+				var marker map[string]string
+				if vars != nil && vars["from"] == "bot" {
+					marker = map[string]string{
+						"from":     "bot",
+						"template": vars["template"],
+					}
+					if vars["template"] == FilePolicyFailType {
+						channelID = "" // hide channelId to mark system messages
+					}
 				}
 				notice := events.MessageEvent{
 					BaseEvent: events.BaseEvent{
@@ -3181,6 +3193,7 @@ func (c *chatService) sendSystemLevelMessage(ctx context.Context, sender *app.Ch
 						ChannelID: channelID,
 						Type:      notify.Type,
 						Text:      notify.Text,
+						Variables: marker,
 						// File:   notify.File,
 						CreatedAt: notify.CreatedAt, // NEW
 						UpdatedAt: notify.UpdatedAt, // EDITED

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -121,7 +121,8 @@ type Message struct {
 	Postback *Postback `json:"postback,omitempty"`
 
 	ReplyToMessageID int64 `json:"reply_to_message_id,omitempty"`
-	MessageForwarded       // embedded
+	Variables        map[string]string `json:"variables,omitempty"`
+	MessageForwarded // embedded
 }
 
 // MessageForwarded event arguments


### PR DESCRIPTION
## Проблема
 Коли клієнт надсилає файл, який порушує політику збереження, через текстовий шлюз БЕЗ налаштованого шаблону `file_policy_fail`, у WebSocket оператора не приходить жодного повідомлення.

## Вирішення
Існуючий маркер `Variables{from:"bot", template:"file_policy_fail"}` (введений у WTEL-7905) досі використовувався лише для внутрішньої маршрутизації в chat-сервісі і не доходив до WS-payload. Тепер ми пробрасуємо цей маркер у WS-event і дозволяємо публікацію service-message з порожнім текстом

# Координація з фронтендом
Перед мерджем потрібна синхронізація з FE та підтвердити, що обробник WS-event не падає на відсутніх полях `text`.