### PR TITLE
chore: add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+WEBITEL_DBO_ADDRESS=postgres://postgres:postgres@postgres:5432/webitel?sslmode=disable&connect_timeout=10
+
+MICRO_REGISTRY=consul
+MICRO_REGISTRY_ADDRESS=127.0.0.1:8500
+MICRO_BROKER=rabbitmq
+MICRO_BROKER_ADDRESS=amqp://admin:admin@rabbit:5672?heartbeat=10
+
+# Public site URL for registering bot-provider webhooks
+WEBITEL_BOT_PROXY=https://example.webitel.com/
+
+# WBTL_LOG_LEVEL=info
+
+# gRPC bind address (0 = random port)
+# MICRO_SERVICE_ADDRESS=127.0.0.1:0
+
+# Bot HTTP bind address (bot unit)
+# WEBITEL_BOT_ADDRESS=127.0.0.1:10030
+
+# WEBITEL_DBO_MAX_OPEN_CONNS=25
+# WEBITEL_DBO_MAX_IDLE_CONNS=25
+# WEBITEL_DBO_CONN_MAX_IDLE_TIME=1m
+# WEBITEL_DBO_CONN_MAX_LIFETIME=5m


### PR DESCRIPTION
Adds a documented `.env.example` (go-micro + WEBITEL_DBO_*/MICRO_* env). Reference/groundwork for the env migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)