### PR TITLE
feat(deb): serve bot assets from /usr/share/webitel

### DIFF
--- a/.env.bot.example
+++ b/.env.bot.example
@@ -21,4 +21,4 @@ WEBITEL_BOT_ADDRESS=127.0.0.1:10030
 # Public HTTP site URL used when registering webhooks with BOT providers
 WEBITEL_BOT_PROXY=https://example.org/chat
 # Base folder where website additional assets are located
-#WEBITEL_BOT_WEB_ROOT=/var/lib/webitel/public-html
+WEBITEL_BOT_WEB_ROOT=/usr/share/webitel/webitel-messages-bot/public-html


### PR DESCRIPTION
Move bot `WEBITEL_BOT_WEB_ROOT` to read-only `/usr/share/webitel/webitel-messages-bot/public-html`.

> Depends on the matching reusable-configs `sync.yml` change (ships the dir under `/usr/share/webitel`). Until that merges + re-syncs, the env points at a not-yet-shipped path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)