### PR TITLE
WTEL-9843: Reject whitespace-only message text

### DIFF
--- a/cmd/chat/service.go
+++ b/cmd/chat/service.go
@@ -2409,7 +2409,9 @@ func (c *chatService) saveMessage(ctx context.Context, dcx sqlx.ExtContext, send
 
 	case "text":
 
-		text := sendMessage.Text
+		// blank, unless one of the candidates below has some non-whitespace text;
+		// so whitespace-only input is rejected the same way as empty input
+		text := ""
 		postback := sendMessage.Postback
 		// coalesce(...)
 		for _, vs := range []string{


### PR DESCRIPTION
## Проблема
Користувач у чатах (Workspace, чат під час відеодзвінка, чат з лендінгу) міг відправити повідомлення, яке складається лише з пробілів - воно проходило валідацію, зберігалось у БД як "   " і розсилалось учасникам чату.

Причина: у saveMessage (гілка case "text") змінна text ініціалізувалась необрізаним значенням sendMessage.Text. Цикл coalesce перезаписував її лише тоді, коли один із кандидатів (текст, текст postback, код postback) після TrimSpace виявлявся непорожнім. Для повідомлення з самих пробілів жоден кандидат цю умову не проходив, text залишався "   " і перевірка text == "" не спрацьовувала.

## Вирішення
Змінено ініціалізацію на text := "". Тепер після циклу coalesce text - це або перший непорожній обрізаний кандидат, або порожній рядок. Повідомлення з самих пробілів обробляється так само, як повністю порожнє, і відхиляється існуючою помилкою chat.send.message.text.missing.