### PR TITLE
SB-114: Fix nil pointer panic on WhatsApp document send

### DIFF
--- a/bot/facebook/whatsapp.go
+++ b/bot/facebook/whatsapp.go
@@ -2307,10 +2307,11 @@ func (c *Client) whatsAppUploadMedia(ctx context.Context, from *whatsapp.WhatsAp
 			if err == nil && rpcErr.Message != "" {
 				err = &rpcErr
 			}
-			if err != nil {
-				formWriter.CloseWithError(err)
-				return
+			if err == nil {
+				err = fmt.Errorf("whatsapp: media source: %s", res.Status)
 			}
+			formWriter.CloseWithError(err)
+			return
 		}
 		// MIMEType from source
 		mediaType, _, err := mime.ParseMediaType(
@@ -2407,6 +2408,10 @@ func (c *Client) whatsAppUploadMedia(ctx context.Context, from *whatsapp.WhatsAp
 
 	if err != nil {
 		return nil, err
+	}
+
+	if rpc.Document == nil || rpc.Document.ID == "" {
+		return nil, fmt.Errorf("whatsapp: upload media %q; no document id returned", media.Name)
 	}
 
 	return rpc.Document, nil
@@ -2527,55 +2532,44 @@ func (c *Client) whatsAppSendUpdate(ctx context.Context, notice *bot.Update) err
 			MediaVideo = "video"
 		)
 
-		var (
-			src = sentMsg.File
-			dst *whatsapp.Document
-		)
+		src := sentMsg.File
+		if src == nil {
+			return microerr.BadRequest(
+				"chat.bot.whatsapp.send.file.missing",
+				"whatsapp: send: message type=file; file is missing",
+			)
+		}
 		for _, mediaType := range []string{
 			MediaImage, MediaAudio, MediaVideo,
 		} {
 			if strings.HasPrefix(src.Mime, mediaType) {
 				if len(src.Mime) == len(mediaType) || src.Mime[len(mediaType)] == '/' {
-					dst, err = c.whatsAppUploadMedia(ctx, sender, src)
-					if err != nil {
-						return err
-					}
 					sendMsg.Type = mediaType
 					break
 				}
 			}
 		}
+		// NOT image/audio/video ? => document (pdf, docx, xlsx, ...)
+		if sendMsg.Type == "" {
+			sendMsg.Type = "document"
+		}
+		dst, err := c.whatsAppUploadMedia(ctx, sender, src)
+		if err != nil {
+			return err
+		}
 		switch sendMsg.Type {
 		case MediaImage:
 			// https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media#upload-media
 			sendMsg.Image = &dst.Media
-			// sendMsg.Image = &whatsapp.Media{
-			// 	ID:      "",
-			// 	Link:    doc.Url,
-			// 	Caption: sentMsg.Text,
-			// }
 		case MediaAudio:
 			sendMsg.Audio = &dst.Media
-			// sendMsg.Audio = &whatsapp.Media{
-			// 	ID:   "",
-			// 	Link: doc.Url,
-			// }
 		case MediaVideo:
 			sendMsg.Video = &dst.Media
-			// sendMsg.Video = &whatsapp.Media{
-			// 	ID:      "",
-			// 	Link:    doc.Url,
-			// 	Caption: sentMsg.Text,
-			// }
-		default:
-			sendMsg.Type = "document"
+		default: // "document"
 			sendMsg.Document = &dst.Media
-			// sendMsg.Document = &whatsapp.Media{
-			// 	ID:       "",
-			// 	Link:     doc.Url,
-			// 	Caption:  sentMsg.Text,
-			// 	Filename: doc.Name,
-			// }
+			// The extension of the filename specifies what format
+			// the document is displayed as in WhatsApp
+			sendMsg.Document.Filename = src.Name
 		}
 
 	case "joined": // ACK: ChatService.JoinConversation()
@@ -2673,7 +2667,7 @@ func (c *Client) whatsAppSendUpdate(ctx context.Context, notice *bot.Update) err
 	}
 
 	// TARGET[chat_id]: MESSAGE[message_id]
-	if len(res.Messages) == 1 {
+	if res != nil && len(res.Messages) == 1 {
 		WAMID := res.Messages[0].ID
 		setVar(chatId, WAMID)
 	}


### PR DESCRIPTION
## Проблема
Файли, що не є зображенням/аудіо/відео (наприклад PDF), не відправлялись клієнту у WhatsApp. У логах BOTS - panic recovered: runtime error: invalid memory address or nil pointer dereference, оператор отримував Internal Server Error.

Причина: у whatsAppSendUpdate (кейс file) завантаження медіа у Graph API (whatsAppUploadMedia) викликалось лише для mime-типів image/, audio/, video/. Для документів цикл не спрацьовував, вказівник dst *whatsapp.Document залишався nil, і гілка default падала на sendMsg.Document = &dst.Media. Відправка документів через діалоговий шлях WhatsApp Cloud API не працювала з моменту написання цього коду.

## Вирішення
Тип повідомлення тепер визначається окремо від завантаження: якщо mime не image/audio/video - це document. Завантаження виконується один раз для всіх типів, після чого зібраний media id підставляється у відповідне поле повідомлення. Валідацію підтримуваних типів файлів виконує сама Meta на етапі upload, тому непідтримуваний тип повертає зрозумілу помилку замість паніки.

## Зміни
- bot/facebook/whatsapp.go, whatsAppSendUpdate (кейс file):
  - файли, що не є image/audio/video, тепер завантажуються та відправляються як document з заповненим filename (без нього WhatsApp не показує ім'я та формат документа)
  - виклик whatsAppUploadMedia винесено в одне місце замість дублювання по гілках
  - додано guard на Message.File == nil (повідомлення типу file без файлу повертає BadRequest замість nil-паніки)
  - додано перевірку res != nil перед res.Messages після відправки (за прикладом broadcast-шляху у provider.go)
- bot/facebook/whatsapp.go, whatsAppUploadMedia:
  - функція більше не повертає (nil, nil): якщо Graph API відповів 200 без id, повертається помилка - захищає всіх поточних і майбутніх викликачів (за патерном whatsAppDownloadMedia)
  - помилка сховища при статусі не-200 без тіла storageError більше не проковтується: повертається помилка зі статусом замість завантаження сміття у WhatsApp